### PR TITLE
Add an iterator implementation for Component

### DIFF
--- a/src/models/Component.js
+++ b/src/models/Component.js
@@ -66,6 +66,16 @@ class Component {
       this.children.push(child);
     }
   }
+
+  * [Symbol.iterator]() {
+    const allDescendants = this.children.slice();
+    yield this;
+    while (allDescendants.length !== 0) {
+      const child = allDescendants.shift();
+      yield child;
+      allDescendants.push(...child.children);
+    }
+  }
 }
 
 export default Component;

--- a/tests/unit/models/Component.spec.js
+++ b/tests/unit/models/Component.spec.js
@@ -112,5 +112,21 @@ describe('Test class: Component', () => {
         expect(parent.children.length).toEqual(1);
       });
     });
+
+    describe('Test method: iterator', () => {
+      it('Should collect all the tree into an array', () => {
+        const root = new Component('root', 'root');
+        const a = new Component('a', 'a');
+        const b = new Component('b', 'b');
+        const c = new Component('c', 'c');
+        const d = new Component('d', 'd');
+        root.children.push(a);
+        root.children.push(b);
+        a.children.push(c);
+        c.children.push(d);
+        const allComponents = Array.from(root);
+        expect(allComponents).toStrictEqual([root, a, b, c, d]);
+      });
+    });
   });
 });


### PR DESCRIPTION
# RFC

Allows consumers of the library to iterate over all the tree
without knowledge of the internal structure.


