### PR TITLE
Bugfix/component disappear when select first

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the bug that made the plugin core crash when reloading with a selected component not yet displayed
+
 ## [0.15.0] - 2023/03/31
 
 ### Added

--- a/cypress/e2e/link-creation.feature
+++ b/cypress/e2e/link-creation.feature
@@ -89,11 +89,9 @@ Feature: Test link creation
     And I expect "#link-laptop-network_link-internal1-network1" is visible
     And I expect "#link-server-laptop_link-server2-internal1" is visible
     And I expect "#link-server-network_link-server2-network2" is visible
-        And I expect "#link-__workflow-__next-wfstep1-wfstep2" is visible
+    And I expect "#link-__workflow-__next-wfstep1-wfstep2" is visible
     And I expect "#link-__workflow-__next-wfstep2-wfstep3" is visible
     And I expect "#link-__workflow-__next-wfstep3-wfstep4" is visible
     And I expect "#link-__workflow-__next-wfstep5-wfstep6" is visible
     And I expect "#link-__workflow-__next-wfstep6-wfstep7" is visible
     And I expect "#link-__workflow-__next-wfstep7-wfstep8" is visible
-
-

--- a/cypress/e2e/renderer.feature
+++ b/cypress/e2e/renderer.feature
@@ -42,3 +42,46 @@ Feature: Test plugin renderer
     And I expect "#link-__workflow-__next-wfstep5-wfstep6" is visible
     And I expect "#link-__workflow-__next-wfstep6-wfstep7" is visible
     And I expect "#link-__workflow-__next-wfstep7-wfstep8" is visible
+
+Scenario: Reset components with a selected component that does not exist
+  Then I expect ".component" appear 16 times on screen
+  And I expect ".component-DefaultModel" appear 12 times on screen
+  And I expect ".component-DefaultContainer" appear 4 times on screen
+  And I expect "#internal1" is visible
+  And I expect "#network1" is visible
+  And I expect "#network2" is visible
+  And I expect "#external1" is visible
+  And I expect "#server1" is visible
+  And I expect "#server2" is visible
+  And I expect "#workflow1" is visible
+  And I expect "#wfstep4" is visible
+  And I expect "#wfstep3" is visible
+  And I expect "#wfstep2" is visible
+  And I expect "#wfstep1" is visible
+  And I expect "#workflow2" is visible
+  And I expect "#wfstep8" is visible
+  And I expect "#wfstep7" is visible
+  And I expect "#wfstep6" is visible
+  And I expect "#wfstep5" is visible
+
+  When I click on "#internal1"
+  And I click on ".reset-btn"
+  Then I expect ".component" appear 16 times on screen
+  And I expect ".component-DefaultModel" appear 12 times on screen
+  And I expect ".component-DefaultContainer" appear 4 times on screen
+  And I expect "#internal1" is visible
+  And I expect "#network1" is visible
+  And I expect "#network2" is visible
+  And I expect "#external1" is visible
+  And I expect "#server1" is visible
+  And I expect "#server2" is visible
+  And I expect "#workflow1" is visible
+  And I expect "#wfstep4" is visible
+  And I expect "#wfstep3" is visible
+  And I expect "#wfstep2" is visible
+  And I expect "#wfstep1" is visible
+  And I expect "#workflow2" is visible
+  And I expect "#wfstep8" is visible
+  And I expect "#wfstep7" is visible
+  And I expect "#wfstep6" is visible
+  And I expect "#wfstep5" is visible

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -19,7 +19,7 @@
       }
     },
     "..": {
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Mozilla Public License Version 2.0",
       "dependencies": {
         "d3": "=7.8.2",

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -5,6 +5,7 @@
     </div>
     <div>
       <button @click="savePosition">Save position</button>
+      <button class="reset-btn" @click="reset">Reset UI</button>
     </div>
     <div id='root'></div>
   </main>
@@ -14,7 +15,7 @@
 import { onMounted } from 'vue';
 import resources from './assets/resources';
 import DemoPlugin from '@/DemoPlugin';
-import { ComponentDrawOption, FileInput } from 'leto-modelizer-plugin-core';
+import { Component, ComponentDrawOption, FileInput } from 'leto-modelizer-plugin-core';
 
 function next(data) {
   console.log(data);
@@ -24,6 +25,11 @@ function savePosition() {
   const configuration = new FileInput({ path: 'localstorage', content: '' });
   plugin.render(configuration);
   window.localStorage.setItem('configuration', configuration.content);
+}
+
+function reset() {
+  document.querySelector('#root').innerHTML = '';
+  plugin.draw('root');
 }
 
 const plugin = new DemoPlugin(next);

--- a/src/draw/DefaultDrawer.js
+++ b/src/draw/DefaultDrawer.js
@@ -1157,6 +1157,12 @@ class DefaultDrawer {
     if (this.actions.selection.current) {
       const selectedComponent = d3.select(`#${this.rootId} .selected`);
 
+      if (selectedComponent.empty()) {
+        this.actions.selection.current = null;
+
+        return;
+      }
+
       if (selectedComponent.classed('component')) {
         selectedComponent
           .classed('selected', false)

--- a/tests/unit/draw/DefaultDrawer.spec.js
+++ b/tests/unit/draw/DefaultDrawer.spec.js
@@ -15,7 +15,7 @@ jest.mock('d3', () => {
     'each', 'enter', 'exit', 'getBBox', 'on', 'linkHorizontal',
     'remove', 'select', 'selectAll', 'style', 'select',
     'text', 'node', 'html', 'transition', 'duration', 'datum',
-    'source', 'target', 'join',
+    'source', 'target', 'join', 'empty',
   ].forEach((method) => {
     mockD3[method] = jest.fn(() => mockD3);
   });
@@ -587,19 +587,37 @@ describe('Test Class: DefaultDrawer()', () => {
 
     describe('Test action: __unselectComponent', () => {
       it('On no selected component Should do nothing', () => {
+        d3.empty.mockReturnValue(false);
         drawer.actions.selection.current = null;
         drawer.__unselectComponent();
 
         expect(drawer.actions.selection.current).toBeNull();
+        expect(d3.empty).not.toBeCalled();
+        expect(d3.classed).not.toBeCalled();
         expect(d3.select).not.toBeCalled();
         expect(d3.style).not.toBeCalled();
       });
 
-      it('On selected component Should unselect it', () => {
-        drawer.actions.selection.current = 'id1';
+      it('On selected component is [null]', () => {
+        d3.empty.mockReturnValue(true);
+        drawer.actions.selection.current = new Component({});
         drawer.__unselectComponent();
 
         expect(drawer.actions.selection.current).toBeNull();
+        expect(d3.empty).toBeCalledTimes(1);
+        expect(d3.classed).not.toBeCalled();
+        expect(d3.select).toBeCalledTimes(1);
+        expect(d3.style).not.toBeCalled();
+      });
+
+      it('On selected component Should unselect it', () => {
+        d3.empty.mockReturnValue(false);
+        drawer.actions.selection.current = new Component({});
+        drawer.__unselectComponent();
+
+        expect(drawer.actions.selection.current).toBeNull();
+        expect(d3.empty).toBeCalledTimes(2);
+        expect(d3.classed).toBeCalledTimes(2);
         expect(d3.select).toBeCalled();
         expect(d3.style).toBeCalled();
       });


### PR DESCRIPTION
Fixed the bug that made the plugin core crash when reloading with a selected component not yet displayed

