### PR TITLE
Feature: rework folders

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `renderConfiguration` method of `DefaultRender`.
   - `parse` method of `DefaultPlugin`.
   - `render` method of `DefaultPlugin`.
+- Add `restrictiveFolder` in `DefaultConfiguration`.
+
+### Removed
+
+- Method `getModelFolders` from `DefaultPlugin` and `DefautParser`.
 
 ## [0.16.0] - 2023/06/06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,13 +28,13 @@
         "eslint-formatter-json-relative": "=0.1.0",
         "eslint-plugin-cypress": "=2.13.3",
         "eslint-plugin-import": "=2.27.5",
-        "eslint-plugin-jsdoc": "=46.3.0",
+        "eslint-plugin-jsdoc": "=46.4.2",
         "eslint-watch": "=8.0.0",
         "jest": "=29.5.0",
         "jest-environment-jsdom": "=29.5.0",
         "jest-sonar-reporter": "=2.0.0",
         "jsdoc": "=4.0.2",
-        "webpack": "=5.88.0",
+        "webpack": "=5.88.1",
         "webpack-cli": "=5.1.4"
       }
     },
@@ -8369,9 +8369,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "46.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.3.0.tgz",
-      "integrity": "sha512-nfSvsR8YJRZyKrWwcXPSQyQC8jllfdEjcRhTXFr7RxfB5Wyl7AxrfjCUz72WwalkXMF4u+R6F/oDoW46ah69HQ==",
+      "version": "46.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.2.tgz",
+      "integrity": "sha512-fmIgOe7irf9otkMtsPjr5P39wC5LzA6aEU/nydfUlc8JaEiS93uhPaxI+x/v5s1Ckm+IZeP3006do2n2ehZcNQ==",
       "dev": true,
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.39.4",
@@ -16629,9 +16629,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.88.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.0.tgz",
-      "integrity": "sha512-O3jDhG5e44qIBSi/P6KpcCcH7HD+nYIHVBhdWFxcLOcIGN8zGo5nqF3BjyNCxIh4p1vFdNnreZv2h2KkoAw3lw==",
+      "version": "5.88.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
+      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -23584,9 +23584,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "46.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.3.0.tgz",
-      "integrity": "sha512-nfSvsR8YJRZyKrWwcXPSQyQC8jllfdEjcRhTXFr7RxfB5Wyl7AxrfjCUz72WwalkXMF4u+R6F/oDoW46ah69HQ==",
+      "version": "46.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.2.tgz",
+      "integrity": "sha512-fmIgOe7irf9otkMtsPjr5P39wC5LzA6aEU/nydfUlc8JaEiS93uhPaxI+x/v5s1Ckm+IZeP3006do2n2ehZcNQ==",
       "dev": true,
       "requires": {
         "@es-joy/jsdoccomment": "~0.39.4",
@@ -29804,9 +29804,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.88.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.0.tgz",
-      "integrity": "sha512-O3jDhG5e44qIBSi/P6KpcCcH7HD+nYIHVBhdWFxcLOcIGN8zGo5nqF3BjyNCxIh4p1vFdNnreZv2h2KkoAw3lw==",
+      "version": "5.88.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
+      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -47,13 +47,13 @@
     "eslint-formatter-json-relative": "=0.1.0",
     "eslint-plugin-cypress": "=2.13.3",
     "eslint-plugin-import": "=2.27.5",
-    "eslint-plugin-jsdoc": "=46.3.0",
+    "eslint-plugin-jsdoc": "=46.4.2",
     "eslint-watch": "=8.0.0",
     "jest": "=29.5.0",
     "jest-environment-jsdom": "=29.5.0",
     "jest-sonar-reporter": "=2.0.0",
     "jsdoc": "=4.0.2",
-    "webpack": "=5.88.0",
+    "webpack": "=5.88.1",
     "webpack-cli": "=5.1.4"
   },
   "dependencies": {

--- a/src/models/DefaultConfiguration.js
+++ b/src/models/DefaultConfiguration.js
@@ -8,6 +8,7 @@ class DefaultConfiguration {
    * @param {object} [props.editor] - Object that contains all properties of editor
    * configuration.
    * @param {object} [props.editor.syntax] - Syntax configuration.
+   * @param {string} [props.restrictiveFolder] - Restrictive folder for new component if provided.
    * @param {string} [props.defaultFileName] - Default file name for new components.
    * @param {string} [props.defaultFileExtension] - Default file extension for components.
    * @param {Tag[]} [props.tags] - All plugin tags.
@@ -16,6 +17,7 @@ class DefaultConfiguration {
     editor: {
       syntax: null,
     },
+    restrictiveFolder: null,
     defaultFileName: null,
     defaultFileExtension: null,
     tags: [],
@@ -28,6 +30,11 @@ class DefaultConfiguration {
       syntax: null,
       ...props.editor,
     };
+    /**
+     * Restrictive folder for new component if provided.
+     * @type {string}
+     */
+    this.restrictiveFolder = props.restrictiveFolder || null;
     /**
      * Default file name for new components.
      * @type {string}

--- a/src/models/DefaultPlugin.js
+++ b/src/models/DefaultPlugin.js
@@ -144,15 +144,6 @@ class DefaultPlugin {
   }
 
   /**
-   * Get all possible folders for a model from a folder list.
-   * @param {FileInformation[]} folders - Folder list.
-   * @returns {string[]} All possible folder list.
-   */
-  getModelFolders(folders) {
-    return this.__parser.getModelFolders(folders);
-  }
-
-  /**
    * Return all generated files from plugin data.
    * Configuration file is used for saving the components' configuration.
    * @param {FileInformation} diagram - Diagram file information.

--- a/src/parser/DefaultParser.js
+++ b/src/parser/DefaultParser.js
@@ -37,15 +37,6 @@ class DefaultParser {
   }
 
   /**
-   * Get all possible folders for a model from a folder list.
-   * @param {FileInformation[]} [folders] - Folder list.
-   * @returns {string[]} All possible folder list.
-   */
-  getModelFolders(folders = []) {
-    return folders.map(({ path }) => path);
-  }
-
-  /**
    * Set configuration into Components.
    * @param {FileInformation} diagram - Diagram file information.
    * @param {FileInput} file - Configuration file of components.

--- a/tests/unit/models/DefaultConfiguration.spec.js
+++ b/tests/unit/models/DefaultConfiguration.spec.js
@@ -6,6 +6,7 @@ describe('Test class: DefaultConfiguration', () => {
       const config = new DefaultConfiguration();
 
       expect(config.editor).toEqual({ syntax: null });
+      expect(config.restrictiveFolder).toBeNull();
       expect(config.defaultFileName).toBeNull();
       expect(config.defaultFileExtension).toBeNull();
       expect(config.tags).toEqual([]);
@@ -15,6 +16,7 @@ describe('Test class: DefaultConfiguration', () => {
       const config = new DefaultConfiguration({});
 
       expect(config.editor).toEqual({ syntax: null });
+      expect(config.restrictiveFolder).toBeNull();
       expect(config.defaultFileName).toBeNull();
       expect(config.defaultFileExtension).toBeNull();
       expect(config.tags).toEqual([]);
@@ -25,12 +27,14 @@ describe('Test class: DefaultConfiguration', () => {
         editor: {
           syntax: true,
         },
+        restrictiveFolder: 'root',
         defaultFileName: 'test',
         defaultFileExtension: '.test',
         tags: ['test'],
       });
 
       expect(config.editor).toEqual({ syntax: true });
+      expect(config.restrictiveFolder).toEqual('root');
       expect(config.defaultFileName).toEqual('test');
       expect(config.defaultFileExtension).toEqual('.test');
       expect(config.tags).toEqual(['test']);

--- a/tests/unit/models/DefaultPlugin.spec.js
+++ b/tests/unit/models/DefaultPlugin.spec.js
@@ -119,31 +119,6 @@ describe('Test class: DefaultPlugin', () => {
     });
   });
 
-  describe('Test method: getModelFolders', () => {
-    it('should return an empty array if there are no folders', () => {
-      const plugin = new DefaultPlugin({
-        pluginParser: {
-          getModelFolders: (files) => files || [],
-        },
-      });
-
-      expect(plugin.getModelFolders()).toEqual([]);
-      expect(plugin.getModelFolders([])).toEqual([]);
-    });
-
-    it('should return all folders', () => {
-      const plugin = new DefaultPlugin({
-        pluginParser: {
-          getModelFolders: (files) => files.map(({ path }) => path),
-        },
-      });
-
-      expect(plugin.getModelFolders([
-        new FileInformation({ path: 'folder' }),
-      ])).toEqual(['folder']);
-    });
-  });
-
   describe('Test method: getModels', () => {
     it('should return an empty array if there are no folders', () => {
       const plugin = new DefaultPlugin({

--- a/tests/unit/parser/DefaultParser.spec.js
+++ b/tests/unit/parser/DefaultParser.spec.js
@@ -67,23 +67,6 @@ describe('Test Class: DefaultParser()', () => {
     });
   });
 
-  describe('Test method: getModelFolders', () => {
-    it('should return empty array without folders', () => {
-      const defaultParser = new DefaultParser();
-
-      expect(defaultParser.getModelFolders()).toEqual([]);
-    });
-
-    it('should provided folders array', () => {
-      const defaultParser = new DefaultParser();
-
-      expect(defaultParser.getModelFolders([])).toEqual([]);
-      expect(defaultParser.getModelFolders([
-        new FileInformation({ path: 'a' }),
-      ])).toEqual(['a']);
-    });
-  });
-
   it('should save configuration even if the file content is null', () => {
     const pluginData = new DefaultData({ name: 'test' });
     const defaultParser = new DefaultParser(pluginData);


### PR DESCRIPTION
Remove `getModelFolders` and add `restrictiveFolder` attribute in configuration.

`restrictiveFolder` is used to force user to create component in this specific folder.

