### PR TITLE
Feature: Reposition a component

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add optional containerId argument to `DefaultLayout.rearrangeComponentsPosition`.
+- Add `repositionComponent` method in `DefaultDrawer`, `DefaultPlugin` and `DefaultLayout`.
+- Add a default implementation for `repositionComponent` in  `ElkLayout`.
+- Add to the demo a button to log components position.
 
 ### Changed
 

--- a/cypress/e2e/automatic-layout.feature
+++ b/cypress/e2e/automatic-layout.feature
@@ -6,76 +6,152 @@ Feature: Test automatic layout for the graph
 
   Scenario: Automatic layout should have a (deterministic) given result
     # Initial positions
-    Then I expect "#__shadowRoot" to be at position 0,0
-    And I expect "#external1" to be at position 918,30
-    And I expect "#internal1" to be at position 42,666
+    Then I expect "#internal1" to be at position 42,666
     And I expect "#network1" to be at position 314,30
     And I expect "#network2" to be at position 646,30
+    And I expect "#external1" to be at position 918,30
     And I expect "#server1" to be at position 30,30
     And I expect "#server2" to be at position 30,110
+    And I expect "#workflow1" to be at position 1190,30
     And I expect "#wfstep1" to be at position 30,30
     And I expect "#wfstep2" to be at position 30,110
     And I expect "#wfstep3" to be at position 30,190
     And I expect "#wfstep4" to be at position 30,270
+    And I expect "#workflow2" to be at position 30,484
     And I expect "#wfstep5" to be at position 30,30
     And I expect "#wfstep6" to be at position 302,30
     And I expect "#wfstep7" to be at position 574,30
     And I expect "#wfstep8" to be at position 846,30
-    And I expect "#workflow1" to be at position 1190,30
-    And I expect "#workflow2" to be at position 30,484
 
     # Rearrange everything
     When I click on "#automatic-layout-children-button"
-    Then I expect "#__shadowRoot" to be at position 0,0
-    And I expect "#external1" to be at position 650,782
-    And I expect "#internal1" to be at position 12,782
+
+    Then I expect "#internal1" to be at position 12,782
     And I expect "#network1" to be at position 292,684
     And I expect "#network2" to be at position 12,12
+    And I expect "#external1" to be at position 650,782
     And I expect "#server1" to be at position 12,12
     And I expect "#server2" to be at position 12,112
+    And I expect "#workflow1" to be at position 292,12
     And I expect "#wfstep1" to be at position 30,30
     And I expect "#wfstep2" to be at position 30,110
     And I expect "#wfstep3" to be at position 30,190
     And I expect "#wfstep4" to be at position 30,270
+    And I expect "#workflow2" to be at position 12,468
     And I expect "#wfstep5" to be at position 30,30
     And I expect "#wfstep6" to be at position 302,30
     And I expect "#wfstep7" to be at position 574,30
     And I expect "#wfstep8" to be at position 846,30
-    And I expect "#workflow1" to be at position 292,12
-    And I expect "#workflow2" to be at position 12,468
 
 
 
   Scenario: Automatic layout should have a (deterministic) given result when reorganizing a node's children
     # Initial positions
-    Then I expect "#__shadowRoot" to be at position 0,0
-    And I expect "#external1" to be at position 918,30
-    And I expect "#internal1" to be at position 42,666
+    Then I expect "#internal1" to be at position 42,666
     And I expect "#network1" to be at position 314,30
     And I expect "#network2" to be at position 646,30
+    And I expect "#external1" to be at position 918,30
     And I expect "#server1" to be at position 30,30
     And I expect "#server2" to be at position 30,110
+    And I expect "#workflow1" to be at position 1190,30
     And I expect "#wfstep1" to be at position 30,30
     And I expect "#wfstep2" to be at position 30,110
     And I expect "#wfstep3" to be at position 30,190
     And I expect "#wfstep4" to be at position 30,270
+    And I expect "#workflow2" to be at position 30,484
     And I expect "#wfstep5" to be at position 30,30
     And I expect "#wfstep6" to be at position 302,30
     And I expect "#wfstep7" to be at position 574,30
     And I expect "#wfstep8" to be at position 846,30
-    And I expect "#workflow1" to be at position 1190,30
-    And I expect "#workflow2" to be at position 30,484
 
     # Rearrange children of network1
     When I select "network1" in "#automatic-layout-children-input"
     And I click on "#automatic-layout-children-button"
-    Then I expect "#__shadowRoot" to be at position 0,0
-    And I expect "#external1" to be at position 918,30
-    And I expect "#internal1" to be at position 42,666
+
+    Then I expect "#internal1" to be at position 42,666
     And I expect "#network1" to be at position 314,30
     And I expect "#network2" to be at position 646,30
+    And I expect "#external1" to be at position 918,30
     And I expect "#server1" to be at position 12,12
     And I expect "#server2" to be at position 12,112
+    And I expect "#workflow1" to be at position 1190,30
+    And I expect "#wfstep1" to be at position 30,30
+    And I expect "#wfstep2" to be at position 30,110
+    And I expect "#wfstep3" to be at position 30,190
+    And I expect "#wfstep4" to be at position 30,270
+    And I expect "#workflow2" to be at position 30,484
+    And I expect "#wfstep5" to be at position 30,30
+    And I expect "#wfstep6" to be at position 302,30
+    And I expect "#wfstep7" to be at position 574,30
+    And I expect "#wfstep8" to be at position 846,30
+
+  Scenario: New components should be added in free space
+
+    Then I expect "#laptop_1" to not exist
+    And I expect "#laptop_2" to not exist
+    And I expect "#laptop_3" to not exist
+    And I expect "#laptop_4" to not exist
+    And I expect "#laptop_5" to not exist
+    And I expect "#laptop_6" to not exist
+    And I expect "#laptop_7" to not exist
+    And I expect "#laptop_8" to not exist
+    And I expect "#laptop_9" to not exist
+    And I expect "#laptop_10" to not exist
+    And I expect "#laptop_11" to not exist
+    And I expect "#laptop_12" to not exist
+    And I expect "#laptop_13" to not exist
+    And I expect "#laptop_14" to not exist
+    And I expect "#laptop_15" to not exist
+    And I expect "#laptop_16" to not exist
+    And I expect "#laptop_17" to not exist
+    And I expect "#laptop_18" to not exist
+
+    # 18 times
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+    When I click on "#add-component-button"
+
+
+    And I expect "#__shadowRoot" to be at position 0,0
+    And I expect "#external1" to be at position 918,30
+    And I expect "#internal1" to be at position 42,666
+    And I expect "#laptop_1" to be at position 30,30
+    And I expect "#laptop_10" to be at position 1170,450
+    And I expect "#laptop_11" to be at position 1170,520
+    And I expect "#laptop_12" to be at position 1170,590
+    And I expect "#laptop_13" to be at position 1170,660
+    And I expect "#laptop_14" to be at position 1420,450
+    And I expect "#laptop_15" to be at position 1420,520
+    And I expect "#laptop_16" to be at position 1420,590
+    And I expect "#laptop_17" to be at position 1420,660
+    And I expect "#laptop_18" to be at position 1510,30
+    And I expect "#laptop_2" to be at position 30,100
+    And I expect "#laptop_3" to be at position 470,290
+    And I expect "#laptop_4" to be at position 470,360
+    And I expect "#laptop_5" to be at position 630,180
+    And I expect "#laptop_6" to be at position 720,250
+    And I expect "#laptop_7" to be at position 720,320
+    And I expect "#laptop_8" to be at position 720,390
+    And I expect "#laptop_9" to be at position 880,180
+    And I expect "#network1" to be at position 314,30
+    And I expect "#network2" to be at position 646,30
+    And I expect "#server1" to be at position 30,30
+    And I expect "#server2" to be at position 30,110
     And I expect "#wfstep1" to be at position 30,30
     And I expect "#wfstep2" to be at position 30,110
     And I expect "#wfstep3" to be at position 30,190

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -15,7 +15,15 @@
       >
         Reset UI
       </button>
-
+      <button
+        id="add-component-button"
+        @click="addComponent"
+      >
+        Add component
+      </button>
+      <button @click="gherkinTestsToConsole">
+        Log components position
+      </button>
       <label for="read-only-checkbox">Read-only ?</label>
       <input
         id="read-only-checkbox"
@@ -120,6 +128,8 @@
 </template>
 
 <script setup>
+/* eslint no-console: 0 */
+
 import { onMounted, ref } from 'vue';
 import { ComponentDrawOption, FileInput, FileInformation } from 'leto-modelizer-plugin-core';
 import resources from './assets/resources';
@@ -136,8 +146,8 @@ const selectedAutoLayoutId = ref('');
 const watchEvents = ['delete', 'add'];
 
 /**
- *
- * @param data
+ * Callback for DemoPlugin instance.
+ * @param {*} data - The data to be logged.
  */
 function next(data) {
   console.log(data);
@@ -166,7 +176,7 @@ plugin.init();
 plugin.initResources(resources);
 
 /**
- *
+ * Save position.
  */
 function savePosition() {
   const configuration = new FileInput({ path: 'localstorage', content: '' });
@@ -176,7 +186,7 @@ function savePosition() {
 }
 
 /**
- *
+ * Rearrange children of a given component, or all of them.
  */
 async function automaticLayoutOfChildren() {
   await plugin.arrangeComponentsPosition(selectedAutoLayoutId.value === ''
@@ -186,7 +196,7 @@ async function automaticLayoutOfChildren() {
 }
 
 /**
- *
+ * Reset the view.
  */
 function reset() {
   document.querySelector('#root').innerHTML = '';
@@ -194,7 +204,7 @@ function reset() {
 }
 
 /**
- *
+ * Rename a component.
  */
 function renameComponent() {
   plugin.data.renameComponentId(selectedId.value, renamedId.value);
@@ -206,7 +216,7 @@ function renameComponent() {
 }
 
 /**
- *
+ * Update components identifiers.
  */
 function updateComponentsIds() {
   componentsIds.value = plugin.data.components.map(({ id }) => id);
@@ -220,6 +230,40 @@ onMounted(() => {
   plugin.draw('root');
   updateComponentsIds();
 });
+
+/**
+ * Add a component to the model and update the view.
+ */
+function addComponent() {
+  const id = plugin.data.addComponent(plugin.data.__laptopDefinition);
+
+  // As of now, we need to draw the component before repositioning it.
+  // That is because we need the component drawOption property to be defined.
+  plugin.draw('root');
+
+  plugin.repositionComponent(id);
+  plugin.draw('root');
+}
+
+/**
+ * Log components position to the browser console.
+ */
+function gherkinTestsToConsole() {
+  console.log('-------------------- Start log position');
+  plugin.data.components
+    .map(({ id }) => document.querySelector(`g #${id}`))
+    .map((e) => {
+      if (e.attributes.x === undefined || e.attributes.y === undefined) {
+        return `'${e.id}' does not have valid position`;
+      }
+
+      return `And I expect "#${e.id}" to be at position`
+          + ` ${e.attributes.x.nodeValue},${e.attributes.y.nodeValue}\n`;
+    })
+    .forEach((line) => console.log(line));
+
+  console.log('-------------------- End log position');
+}
 </script>
 
 <style>

--- a/src/draw/DefaultDrawer.js
+++ b/src/draw/DefaultDrawer.js
@@ -1742,5 +1742,13 @@ class DefaultDrawer {
   async arrangeComponentsPosition(containerId) {
     await this.layout.arrangeComponentsPosition(containerId);
   }
+
+  /**
+   * Reposition a component where there is room for it.
+   * @param {string} componentId - Id of a component to be repositioned.
+   */
+  repositionComponent(componentId) {
+    this.layout.repositionComponent(componentId);
+  }
 }
 export default DefaultDrawer;

--- a/src/draw/DefaultLayout.js
+++ b/src/draw/DefaultLayout.js
@@ -28,6 +28,14 @@ class DefaultLayout {
   async arrangeComponentsPosition(containerId) {
     return Promise.resolve();
   }
+
+  /**
+   * Reposition a component where there is room for it.
+   * @param {string} componentId - Id of a component to be repositioned.
+   */
+  // eslint-disable-next-line no-unused-vars
+  repositionComponent(componentId) {
+  }
 }
 
 export default DefaultLayout;

--- a/src/models/DefaultConfiguration.js
+++ b/src/models/DefaultConfiguration.js
@@ -14,6 +14,12 @@ class DefaultConfiguration {
    * @param {Tag[]} [props.tags] - All plugin tags.
    * @param {object} [props.elkParams] - Parameters for the layout algorithm.
    * @see Parameters for ELK: {@link https://eclipse.dev/elk/reference/options.html}
+   * @param {object} [props.singleComponentParams] - Parameters for the algorithm that
+   * places a single component.
+   * @param {number} [props.singleComponentParams.margin] - Minimal distance between
+   * components & links.
+   * @param {number} [props.singleComponentParams.precision] - Space interval between coordinates
+   * that will be tested. Performance decreases proportionally to the square of this parameter.
    */
   constructor(props = {
     editor: {
@@ -24,6 +30,7 @@ class DefaultConfiguration {
     defaultFileExtension: null,
     tags: [],
     elkParams: null,
+    singleComponentParams: null,
   }) {
     /**
      * Object that contains all properties of editor configuration.
@@ -71,6 +78,16 @@ class DefaultConfiguration {
       'elk.debugMode': 'true',
       'elk.direction': 'UNDEFINED',
       ...props.elkParams,
+    };
+
+    /**
+     Parameters for the algorithm that places a single new component.
+     @type {object}
+     */
+    this.singleComponentParams = {
+      precision: 10,
+      margin: 20,
+      ...props.singleComponentParams,
     };
   }
 }

--- a/src/models/DefaultPlugin.js
+++ b/src/models/DefaultPlugin.js
@@ -182,6 +182,14 @@ class DefaultPlugin {
   async arrangeComponentsPosition(containerId) {
     await this.__drawer.arrangeComponentsPosition(containerId);
   }
+
+  /**
+   * Reposition a component where there is room for it.
+   * @param {string} componentId - Id of a component to be repositioned.
+   */
+  repositionComponent(componentId) {
+    this.__drawer.repositionComponent(componentId);
+  }
 }
 
 export default DefaultPlugin;

--- a/tests/unit/draw/DefaultDrawer.spec.js
+++ b/tests/unit/draw/DefaultDrawer.spec.js
@@ -1103,4 +1103,22 @@ describe('Test Class: DefaultDrawer()', () => {
       expect(spyLayout).toHaveBeenCalledWith(argument);
     });
   });
+
+  describe('Test method: repositionComponent', () => {
+    it('should propagate repositionComponent call to this.layout', () => {
+      const drawer = new DefaultDrawer(
+        new DefaultData(),
+        null,
+        'root',
+      );
+
+      const spyRepositionComponent = jest
+        .spyOn(drawer.layout, 'repositionComponent')
+        .mockImplementation(() => undefined);
+      const component = new Component();
+
+      drawer.repositionComponent(component);
+      expect(spyRepositionComponent).toHaveBeenCalledWith(component);
+    });
+  });
 });

--- a/tests/unit/models/DefaultConfiguration.spec.js
+++ b/tests/unit/models/DefaultConfiguration.spec.js
@@ -6,6 +6,7 @@ import DefaultConfiguration from 'src/models/DefaultConfiguration';
 describe('Test class: DefaultConfiguration', () => {
   describe('Test constructor', () => {
     let defaultElkParams;
+    let defaultSingleComponentParams;
 
     beforeEach(() => {
       defaultElkParams = {
@@ -20,6 +21,11 @@ describe('Test class: DefaultConfiguration', () => {
         'elk.debugMode': 'true',
         'elk.direction': 'UNDEFINED',
       };
+
+      defaultSingleComponentParams = {
+        precision: 10,
+        margin: 20,
+      };
     });
 
     it('Check variables instantiation', () => {
@@ -31,6 +37,7 @@ describe('Test class: DefaultConfiguration', () => {
       expect(config.defaultFileExtension).toBeNull();
       expect(config.tags).toEqual([]);
       expect(config.elkParams).toEqual(defaultElkParams);
+      expect(config.singleComponentParams).toEqual(defaultSingleComponentParams);
     });
 
     it('Check passing undefined variables to constructor', () => {
@@ -42,6 +49,7 @@ describe('Test class: DefaultConfiguration', () => {
       expect(config.defaultFileExtension).toBeNull();
       expect(config.tags).toEqual([]);
       expect(config.elkParams).toEqual(defaultElkParams);
+      expect(config.singleComponentParams).toEqual(defaultSingleComponentParams);
     });
 
     it('Check passing all variables to constructor', () => {
@@ -56,6 +64,9 @@ describe('Test class: DefaultConfiguration', () => {
         elkParams: {
           test_attribute: 12345,
         },
+        singleComponentParams: {
+          test_attribute: 12345,
+        },
       });
 
       expect(config.editor).toEqual({ syntax: true });
@@ -65,6 +76,10 @@ describe('Test class: DefaultConfiguration', () => {
       expect(config.tags).toEqual(['test']);
       expect(config.elkParams).toEqual({
         ...defaultElkParams,
+        test_attribute: 12345,
+      });
+      expect(config.singleComponentParams).toEqual({
+        ...defaultSingleComponentParams,
         test_attribute: 12345,
       });
     });

--- a/tests/unit/models/DefaultPlugin.spec.js
+++ b/tests/unit/models/DefaultPlugin.spec.js
@@ -1,3 +1,4 @@
+import Component from 'src/models/Component';
 import DefaultPlugin from 'src/models/DefaultPlugin';
 import DefaultData from 'src/models/DefaultData';
 import DefaultDrawer from 'src/draw/DefaultDrawer';
@@ -272,6 +273,21 @@ describe('Test class: DefaultPlugin', () => {
 
       await plugin.arrangeComponentsPosition(argument);
       expect(spyArrangeComponentsPosition).toHaveBeenCalledWith(argument);
+    });
+  });
+
+  describe('Test method: repositionComponent', () => {
+    it('should propagate repositionComponent call to this.__drawer', () => {
+      const spyRepositionComponent = jest.fn(() => undefined);
+      const plugin = new DefaultPlugin({
+        pluginDrawer: {
+          repositionComponent: spyRepositionComponent,
+        },
+      });
+      const component = new Component();
+
+      plugin.repositionComponent(component);
+      expect(spyRepositionComponent).toHaveBeenCalledWith(component);
     });
   });
 });


### PR DESCRIPTION
I added a method to the DefaultPlugin class to reposition a component where there is free space for it.

The main usage for this is to automatically position newly created components.

![feature](https://github.com/ditrit/leto-modelizer-plugin-core/assets/90899718/248d351d-32c8-4a5c-996e-c7146917826d)
